### PR TITLE
fix(ui): Fix theme toggling by unifying context implementation

### DIFF
--- a/front-end/src/components/ThemeProvider.tsx
+++ b/front-end/src/components/ThemeProvider.tsx
@@ -1,64 +1,34 @@
-import { createContext, useEffect, useState } from "react"
-
-type Theme = "dark" | "light" | "system"
+import { useEffect, useState } from 'react';
+import { Theme, ThemeContext } from './ui/theme-context';
+import type { ThemeProviderState } from './ui/theme-context';
 
 type ThemeProviderProps = {
-  children: React.ReactNode
-  defaultTheme?: Theme
-  storageKey?: string
-}
+  children: React.ReactNode;
+};
 
-type ThemeProviderState = {
-  theme: Theme
-  setTheme: (theme: Theme) => void
-}
-
-const initialState: ThemeProviderState = {
-  theme: "system",
-  setTheme: () => null,
-}
-
-const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
-
-export function ThemeProvider({
-  children,
-  defaultTheme = "system",
-  storageKey = "vite-ui-theme",
-  ...props
-}: ThemeProviderProps) {
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
-  )
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem('vite-ui-theme') as Theme) || 'system');
 
   useEffect(() => {
-    const root = window.document.documentElement
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
 
-    root.classList.remove("light", "dark")
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
-    if (theme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-        .matches
-        ? "dark"
-        : "light"
-
-      root.classList.add(systemTheme)
-      return
+      root.classList.add(systemTheme);
+    } else {
+      root.classList.add(theme);
     }
+  }, [theme]);
 
-    root.classList.add(theme)
-  }, [theme])
-
-  const value = {
+  const value: ThemeProviderState = {
     theme,
-    setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme)
-      setTheme(theme)
+    setTheme: (newTheme: Theme) => {
+      localStorage.setItem('vite-ui-theme', newTheme);
+      setTheme(newTheme);
     },
-  }
+  };
 
-  return (
-    <ThemeProviderContext.Provider {...props} value={value}>
-      {children}
-    </ThemeProviderContext.Provider>
-  )
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/front-end/src/components/layout/MainLayout.tsx
+++ b/front-end/src/components/layout/MainLayout.tsx
@@ -3,12 +3,12 @@ import Navbar from '../Navbar';
 import { ThemeProvider } from '../ThemeProvider';
 
 const MainLayout = () => {
-    return (
-        <ThemeProvider defaultTheme='light' storageKey="vite-ui-theme">
-            <Navbar />
-            <Outlet />
-        </ThemeProvider>
-    );
+  return (
+    <ThemeProvider>
+      <Navbar />
+      <Outlet />
+    </ThemeProvider>
+  );
 };
 
 export default MainLayout;

--- a/front-end/src/components/ui/theme-context.ts
+++ b/front-end/src/components/ui/theme-context.ts
@@ -1,24 +1,23 @@
-import { createContext, useContext } from "react"
+import { createContext, useContext } from 'react';
 
-type Theme = "dark" | "light" | "system"
+export type Theme = 'dark' | 'light' | 'system';
 
 export type ThemeProviderState = {
-  theme: Theme
-  setTheme: (theme: Theme) => void
-}
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
 
 const initialState: ThemeProviderState = {
-  theme: "system",
+  theme: 'system',
   setTheme: () => null,
-}
+};
 
-export const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+export const ThemeContext = createContext<ThemeProviderState>(initialState);
 
-export const useTheme = () => {
-  const context = useContext(ThemeProviderContext)
+export function useTheme() {
+  const context = useContext(ThemeContext);
 
-  if (context === undefined)
-    throw new Error("useTheme must be used within a ThemeProvider")
+  if (context === undefined) throw new Error('useTheme must be used within a ThemeProvider');
 
-  return context
+  return context;
 }


### PR DESCRIPTION
The theme toggle button wasn't working because the app was using two separate
context systems - one defined in ThemeProvider.tsx and another in theme-context.ts.
This fix unifies them by moving type definitions to theme-context.ts and updating
the ThemeProvider to use the shared context.
