### PR TITLE
Improve phone number validation

### DIFF
--- a/back-end/src/main/java/com/matchme/srv/validation/validators/PhoneNumberValidator.java
+++ b/back-end/src/main/java/com/matchme/srv/validation/validators/PhoneNumberValidator.java
@@ -11,11 +11,8 @@ public class PhoneNumberValidator implements ConstraintValidator<ValidPhoneNumbe
 
     @Override
     public boolean isValid(String phoneField, ConstraintValidatorContext context) {
-        if (phoneField == null || phoneField.isBlank()) {
-            return true;
-        }
         try {
-            var phoneNumber = phoneUtil.parse(phoneField, "EE");
+            var phoneNumber = phoneUtil.parse(phoneField, null);
             return phoneUtil.isValidNumber(phoneNumber);
         } catch (NumberParseException e) {
             return false;


### PR DESCRIPTION
Initially this branch was made to allow 7 digit phone numbers, but it seems they were already allowed, I just didn't know (and still don't know) the rules for 7 digit mobile phone numbers. For example, `517 3563` passes, but `5555 444` doesn't. Regardless, this PR now allows all regions (not just `+372`), since we removed the default `"EE"` in back-end, and instead of sending `+372 55554444` in front, we send `+37255554444` and google's util parses the country code automatically.

- **fix(PhoneNumberValidator): allow null region code in phone number parsing**
- **refactor(RegisterForm): consolidate phone number state management**
