### PR TITLE
SCRUM 118 display date and time for each message

### DIFF
--- a/front-end/src/pages/chats/components/Message.tsx
+++ b/front-end/src/pages/chats/components/Message.tsx
@@ -1,4 +1,5 @@
 import { ChatMessageResponseDTO } from '@/api/types';
+import { format, fromUnixTime } from 'date-fns';
 
 interface MessageBoxProps {
   message: ChatMessageResponseDTO;
@@ -16,6 +17,9 @@ export default function Message({ message, isOwn = true }: MessageBoxProps) {
         )}
         <div className={`size-fit rounded-md p-2 px-4 ${isOwn ? 'bg-primary-600 text-white' : 'bg-background-200'}`}>
           {message.content}
+          <div className="flex justify-end">
+            <span className="text-xs">{format(fromUnixTime(Number(message.createdAt)), 'kk:mm')}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/front-end/src/pages/chats/components/OpenChat.tsx
+++ b/front-end/src/pages/chats/components/OpenChat.tsx
@@ -76,7 +76,7 @@ export default function OpenChat() {
     const optimisticMessage: ChatMessageResponseDTO = {
       connectionId: messageDTO.connectionId,
       content: messageDTO.content,
-      createdAt: new Date().toISOString(),
+      createdAt: Math.floor(Date.now() / 1000).toString(),
       messageId: -(chatMessages.length + 1),
       senderAlias: user.alias || '',
       senderId: user.id || 0,


### PR DESCRIPTION
- **fix(OpenChat): use Unix timestamp for optimistic message**
- **feat(Message): display message timestamp**
